### PR TITLE
calc-layout: Added adjustable button sizing and the zero button

### DIFF
--- a/src/components/Key.js
+++ b/src/components/Key.js
@@ -11,17 +11,18 @@ const Button = styled.button`
   font-size: 24px;
   justify-content: center;
   align-items: center;
-  width: ${props => props.size || 75}px;
-  height: ${props => props.size || 75}px;
+  width: ${props => props.width || 75}px;
+  height: ${props => props.height || 75}px;
 `;
 
-export const Key = ({keyValue, size}) => {
-  return <Button size={size}>{keyValue}</Button>
+export const Key = ({keyValue, height, width}) => {
+  return <Button height={height} width={width}>{keyValue}</Button>
 };
 
 Key.propType = {
   keyValue: PropTypes.string,
-  size: PropTypes.number,
+  height: PropTypes.number,
+  width: PropTypes.number,
 };
 
 export default Key;

--- a/src/components/Keypad.js
+++ b/src/components/Keypad.js
@@ -15,11 +15,11 @@ const Row = styled.div`
 export const Keypad = () => {
   return(
     <Div>
-    <Row>
-      <Key keyValue='7' />
-      <Key keyValue='8' />
-      <Key keyValue='9' />
-    </Row>
+      <Row>
+        <Key keyValue='7' />
+        <Key keyValue='8' />
+        <Key keyValue='9' />
+      </Row>
       <Row>
         <Key keyValue='4' />
         <Key keyValue='5' />
@@ -30,6 +30,7 @@ export const Keypad = () => {
         <Key keyValue='2' />
         <Key keyValue='3' />
       </Row>
+      <Key height={75} width={225} keyValue={0} />
     </Div>
   )
 };


### PR DESCRIPTION
Switched from a single size prop to width and height props on the key button to allow for fully adjustable button sizes